### PR TITLE
Add link to Jekit source code in index.html

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -13,6 +13,9 @@
         with <a href="http://www.codeforamerica.org/people/mick-thompson/">Mick Thompson</a>,
         © 2013-2014 <a href="http://codeforamerica.org">Code for America</a>.
     </p>
+    <p>
+        You can view the source code for Jekit on GitHub at <a href="https://github.com/codeforamerica/git-jekyll-preview">https://github.com/codeforamerica/git-jekyll-preview</a>.
+    </p>
     <h3>Check it, before you wreck it.</h3>
     <ol>
     <li>


### PR DESCRIPTION
Was looking around for this and noticed the repo's not called Jekit; if I had a bit of trouble finding it I imagine others might too, so adding a link to the repo into the project overview page.
