### PR TITLE
Allow SSL responses to stay SSL

### DIFF
--- a/chef/apache/recipes/apache-ssl.conf
+++ b/chef/apache/recipes/apache-ssl.conf
@@ -26,8 +26,17 @@
     </Directory>
 
     <Location />
-        RedirectMatch 302 (.*) http://jekit.codeforamerica.org$1
+        ProxyPass http://127.0.0.1:8080/
+        ProxyPassReverse http://127.0.0.1:8080/
     </Location>
+
+    <Proxy http://127.0.0.1:8080/*>
+        Allow from all
+    </Proxy>
+
+    # Apache ProxyPassReverse doesn't seem to understand how to
+    # rewrite headers to the correct URL schema, so we do it here.
+    Header edit Location ^http://jekit.(.*)$ https://jekit.$1
 
     ErrorLog ${APACHE_LOG_DIR}/error.log
 

--- a/chef/apache/recipes/default.rb
+++ b/chef/apache/recipes/default.rb
@@ -25,6 +25,11 @@ link '/etc/apache2/mods-enabled/proxy_http.load' do
     action :create
 end
 
+link '/etc/apache2/mods-enabled/headers.load' do
+    to '/etc/apache2/mods-available/headers.load'
+    action :create
+end
+
 file '/etc/apache2/sites-available/jekit' do
     owner 'root'
     group 'root'


### PR DESCRIPTION
This took some monkeying with Apache Proxy settings.

Closes #6.
