### PR TITLE
Update dependencies so we can use current Jekyll release

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,4 +39,4 @@ To run for testing:
 
 To run in production, with [Gunicorn](http://gunicorn.org):
 
-    gunicorn make-it-so:app
+    gunicorn -b 0.0.0.0:8080 -w 4 -t 300 -e app-logfile=/var/log/jekit/app.log --access-logfile /var/log/jekit/access.log make-it-so:app

--- a/chef/apache/recipes/default.rb
+++ b/chef/apache/recipes/default.rb
@@ -35,7 +35,7 @@ link '/etc/apache2/mods-enabled/headers.load' do
     action :create
 end
 
-file '/etc/apache2/sites-available/jekit' do
+file '/etc/apache2/sites-available/jekit.conf' do
     owner 'root'
     group 'root'
     mode '0755'
@@ -43,21 +43,21 @@ file '/etc/apache2/sites-available/jekit' do
     content File.open(File.dirname(__FILE__) + "/apache-jekit.conf").read()
 end
 
-link '/etc/apache2/sites-enabled/000-default' do
+link '/etc/apache2/sites-enabled/000-default.conf' do
     action :delete
 end
 
-link '/etc/apache2/sites-enabled/jekit' do
-    to '/etc/apache2/sites-available/jekit'
+link '/etc/apache2/sites-enabled/jekit.conf' do
+    to '/etc/apache2/sites-available/jekit.conf'
     action :create
 end
 
-link '/etc/apache2/sites-enabled/default-ssl' do
-    to '/etc/apache2/sites-available/default-ssl'
+link '/etc/apache2/sites-enabled/default-ssl.conf' do
+    to '/etc/apache2/sites-available/default-ssl.conf'
     action :delete
 end
 
-file '/etc/apache2/sites-available/jekit-ssl' do
+file '/etc/apache2/sites-available/jekit-ssl.conf' do
     owner 'root'
     group 'root'
     mode '0755'
@@ -79,8 +79,8 @@ file '/etc/ssl/private/cfa-2014-ssl.key' do
     action :create
 end
 
-link '/etc/apache2/sites-enabled/jekit-ssl' do
-    to '/etc/apache2/sites-available/jekit-ssl'
+link '/etc/apache2/sites-enabled/jekit-ssl.conf' do
+    to '/etc/apache2/sites-available/jekit-ssl.conf'
     action :create
 end
 

--- a/chef/apache/recipes/default.rb
+++ b/chef/apache/recipes/default.rb
@@ -20,6 +20,11 @@ link '/etc/apache2/mods-enabled/ssl.load' do
     action :create
 end
 
+link '/etc/apache2/mods-enabled/socache_shmcb.load' do
+    to '/etc/apache2/mods-available/socache_shmcb.load'
+    action :create
+end
+
 link '/etc/apache2/mods-enabled/proxy_http.load' do
     to '/etc/apache2/mods-available/proxy_http.load'
     action :create

--- a/chef/github-pages/recipes/default.rb
+++ b/chef/github-pages/recipes/default.rb
@@ -1,7 +1,9 @@
-package 'ruby1.9.3'
+package 'ruby2.0'
+package 'ruby2.0-dev'
+package 'zlib1g-dev'
 
 gem_package 'github-pages' do
-    gem_binary '/usr/bin/gem1.9.3'
+    gem_binary '/usr/bin/gem2.0'
     options "--no-rdoc --no-ri"
     action :install
 end

--- a/install.sh
+++ b/install.sh
@@ -4,8 +4,8 @@
 # This script is safe to run multiple times.
 #
 if [ ! `which chef-solo` ]; then
-    apt-get install -y ruby1.9.3 build-essential
-    gem1.9.3 install chef ohai --no-rdoc --no-ri
+    apt-get install -y ruby2.0 ruby2.0-dev build-essential
+    gem2.0 install chef ohai --no-rdoc --no-ri
 fi
 
 BASE=`dirname $0`


### PR DESCRIPTION
This updates the install and chef scripts to use ruby2.0 and install the newest version of the github-pages gem, allowing us to use Jekyll ~2.5. This fixes an issue causing Jekyll to silently fail when it tried to build the current [codeforamerica/codeforamerica.org](http://github.com/codeforamerica/codeforamerica.org) master branch.
- In the install.sh script, we apt-get ruby2.0 and ruby2.0-dev so we can install the most recent version of chef.
- In the github-pages chef recipe, we use ruby2.0, ruby2.0dev and zlib1g-dev pacakges to build the github-pages gem. This gives us the newest version of Jekyll.
- In the apache chef recipe, I updated the scripts to activate a required SSL module that was causing apache to fail at start
- In the apache chef recipe, I also updated the configuration file tasks to use .conf file endings, following apache conventions (this allows for the standard commands a2ensite and a2dissite to be run, and also ensure we delete the default .conf files)
- In the README, I changed the startup command to reflect that guincorn needs some custom flags to run this correctly

Thanks to @wpietri for all the help with chef.

@migurski, I noticed the gunicorn chef recipe creates an upstart script for jekit (looks like it should allow for `$ service start jekit`. Is that how we should be instructing people to start up the app? I couldn't get it to work, so I just ran gunicorn myself.

Feedback on this welcome. I kind of felt around in the dark until I got things to work (with help). You can check out this branch running at http://107.170.241.55 (try (http://107.170.241.55/codeforamerica/codeforamerica.org/master/).
